### PR TITLE
Bugfix/missing route param in request

### DIFF
--- a/src/BW/ActiveMenuItemBundle/Resources/config/services.yml
+++ b/src/BW/ActiveMenuItemBundle/Resources/config/services.yml
@@ -8,6 +8,6 @@ services:
 
     bw_active_menu_item.twig.bw_extension:
         class: BW\ActiveMenuItemBundle\Twig\BWExtension
-        arguments: []
+        arguments: ['@request_stack']
         tags:
             - { name: twig.extension }

--- a/src/BW/ActiveMenuItemBundle/Twig/BWExtension.php
+++ b/src/BW/ActiveMenuItemBundle/Twig/BWExtension.php
@@ -3,6 +3,7 @@
 namespace BW\ActiveMenuItemBundle\Twig;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class BWExtension extends \Twig_Extension
 {
@@ -13,10 +14,12 @@ class BWExtension extends \Twig_Extension
 
     /**
      * Constructor
+     *
+     * @param RequestStack $requestStack
      */
-    public function __construct()
+    public function __construct(RequestStack $requestStack)
     {
-        $this->request = Request::createFromGlobals();
+        $this->request = $requestStack->getCurrentRequest();
     }
 
 


### PR DESCRIPTION
This PR fixes an error in the isActiveFilter and isActiveFunction.

Until now, the request used to compare was created with createFromGlobal. This request did not contain the request parameters in $this->request->attributes->parameters e.g. "_route" which is used for comparison in the is_active filter.

The request stack is available since symfony 2.4 so i think this shouldnt be a BC. right @bocharsky-bw  ?