### PR TITLE
add twig to required packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "twig/twig": "^2.0"
     },
     "autoload": {
         "psr-4": { "": "src" }


### PR DESCRIPTION
This is a hotfix to lock twigs version to ^2.0 since version ^3.0 removed deprecations that cause errors in this bundle.